### PR TITLE
added dist targets (to create source tarballs needed for packaging)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set( CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/strus" )
 set( CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE )
 endif()
 
+include(cmake/dist.cmake)
+
 include(cmake/LinuxDistribution.cmake)
 
 set_property(GLOBAL PROPERTY rule_launch_compile ccache)

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -1,0 +1,21 @@
+# based on http://agateau.com/2009/cmake-and-make-dist-the-simple-version/
+# adapted for various compressors
+
+string(TOLOWER ${CMAKE_PROJECT_NAME} PACKAGE_NAME)
+set(ARCHIVE_NAME ${PACKAGE_NAME}-${STRUS_VERSION})
+add_custom_target(dist
+    COMMAND git archive --prefix=${ARCHIVE_NAME}/ HEAD
+        > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-bz2
+    COMMAND git archive --prefix=${ARCHIVE_NAME}/ HEAD
+        | bzip2 > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.bz2
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-gz
+    COMMAND git archive --prefix=${ARCHIVE_NAME}/ HEAD
+        | gzip > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.gz
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-xz
+    COMMAND git archive --prefix=${ARCHIVE_NAME}/ HEAD
+        | xz > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.xz
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Packages should be built from a source tarballs, never directly from the working directory.
This requires 'make dist' like targets in 'make'.
