### PR TITLE
added an include string for std::size_t (apparently missing on some versions of the C++ utility header)

### DIFF
--- a/include/strus/databaseTransactionInterface.hpp
+++ b/include/strus/databaseTransactionInterface.hpp
@@ -28,6 +28,7 @@
 */
 #ifndef _STRUS_DATABASE_TRANSACTION_INTERFACE_HPP_INCLUDED
 #define _STRUS_DATABASE_TRANSACTION_INTERFACE_HPP_INCLUDED
+#include <string>
 #include <utility>
 
 namespace strus

--- a/include/strus/databaseTransactionInterface.hpp
+++ b/include/strus/databaseTransactionInterface.hpp
@@ -28,7 +28,7 @@
 */
 #ifndef _STRUS_DATABASE_TRANSACTION_INTERFACE_HPP_INCLUDED
 #define _STRUS_DATABASE_TRANSACTION_INTERFACE_HPP_INCLUDED
-#include <string>
+#include <cstring>
 #include <utility>
 
 namespace strus


### PR DESCRIPTION
In theory "#include utility" should define "std::size_t", on some platforms it doesn't (compiler
too old, distribution bug?). Including cstring too in the one place where necessary.
