### PR TITLE
Some fixes on OSX

### DIFF
--- a/src/database_leveldb/CMakeLists.txt
+++ b/src/database_leveldb/CMakeLists.txt
@@ -20,9 +20,9 @@ include_directories(
 )
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${PROJECT_SOURCE_DIR}/3rdParty/getMemorySize/src"
-	"${PROJECT_SOURCE_DIR}/database_leveldb"
+	"${PROJECT_SOURCE_DIR}/src/database_leveldb"
 	"${strusbase_LIBRARY_DIRS}"
 )
 

--- a/src/queryeval/CMakeLists.txt
+++ b/src/queryeval/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(
 )
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${strusbase_LIBRARY_DIRS}"
 )
 

--- a/src/queryproc/CMakeLists.txt
+++ b/src/queryproc/CMakeLists.txt
@@ -21,9 +21,9 @@ include_directories(
 
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${PROJECT_SOURCE_DIR}/src/queryproc/iterator"
-	"${PROJECT_SOURCE_DIR}/src/queryproc/summarize"
+	"${PROJECT_SOURCE_DIR}/src/queryproc/summarizer"
 	"${PROJECT_SOURCE_DIR}/src/queryproc/weighting"
 	"${strusbase_LIBRARY_DIRS}"
 )

--- a/src/scalarfunc/CMakeLists.txt
+++ b/src/scalarfunc/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(
 
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${strusbase_LIBRARY_DIRS}"
 )
 

--- a/src/statsproc/CMakeLists.txt
+++ b/src/statsproc/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(
 
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${PROJECT_SOURCE_DIR}/3rdParty/compactNodeTrie/src" 
 	"${strusbase_LIBRARY_DIRS}"
 )

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -58,9 +58,9 @@ include_directories(
 )
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
-	"${PROJECT_SOURCE_DIR}/database_leveldb"
-	"${PROJECT_SOURCE_DIR}/statsproc"
+	"${PROJECT_SOURCE_DIR}/src/utils"
+	"${PROJECT_SOURCE_DIR}/src/database_leveldb"
+	"${PROJECT_SOURCE_DIR}/src/statsproc"
 	"${PROJECT_SOURCE_DIR}/3rdParty/compactNodeTrie/src" 
 	"${strusbase_LIBRARY_DIRS}"
 )

--- a/src/storage/libstrus_storage_objbuild.cpp
+++ b/src/storage/libstrus_storage_objbuild.cpp
@@ -13,8 +13,9 @@
 #include "strus/lib/statsproc.hpp"
 #include "strus/lib/storage.hpp"
 #include "strus/lib/database_leveldb.hpp"
-#include "strus/reference.hpp"
+#include "strus/queryProcessorInterface.hpp"
 #include "strus/errorBufferInterface.hpp"
+#include "strus/reference.hpp"
 #include "strus/storageObjectBuilderInterface.hpp"
 #include "strus/storageAlterMetaDataTableInterface.hpp"
 #include "strus/storageInterface.hpp"
@@ -42,7 +43,7 @@ public:
 		:m_queryProcessor( strus::createQueryProcessor(errorhnd_))
 		,m_storage(strus::createStorage(errorhnd_))
 		,m_db( strus::createDatabase_leveldb( errorhnd_))
-		,m_statsproc( strus::createStatisticsProcessor( m_errorhnd))
+		,m_statsproc( strus::createStatisticsProcessor( errorhnd_))
 		,m_errorhnd(errorhnd_)
 	{
 		if (!m_queryProcessor.get()) throw strus::runtime_error(_TXT("error creating query processor"));

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
 )
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 	"${strusbase_LIBRARY_DIRS}"
 )
 


### PR DESCRIPTION
Fixes some wrong directories in link_directories in CMakeLists.txt
and some compilation issues:

```
/Users/baumann/work/strus/src/storage/libstrus_storage_objbuild.cpp:45:51: warning: field 'm_errorhnd' is
      uninitialized when used here [-Wuninitialized]
                ,m_statsproc( strus::createStatisticsProcessor( m_errorhnd))
                                                                ^
In file included from /Users/baumann/work/strus/src/storage/libstrus_storage_objbuild.cpp:16:
/usr/local/include/strus/reference.hpp:39:4: warning: deleting pointer to incomplete type
      'strus::QueryProcessorInterface' may cause undefined behavior [-Wdelete-incomplete]
                        delete m_obj;
                        ^      ~~~~~
/Users/baumann/work/strus/src/storage/libstrus_storage_objbuild.cpp:42:4: note: in instantiation of
      member function 'strus::Reference<strus::QueryProcessorInterface>::Reference' requested here
                :m_queryProcessor( strus::createQueryProcessor(errorhnd_))
                 ^
/Users/baumann/work/strus/include/strus/lib/queryeval.hpp:22:7: note: forward declaration of
      'strus::QueryProcessorInterface'
class QueryProcessorInterface;
      ^
In file included from /Users/baumann/work/strus/src/storage/libstrus_storage_objbuild.cpp:16:
/usr/local/include/strus/reference.hpp:137:4: warning: deleting pointer to incomplete type
      'strus::QueryProcessorInterface' may cause undefined behavior [-Wdelete-incomplete]
                        delete m_obj;
                        ^      ~~~~~
/usr/local/include/strus/reference.hpp:52:3: note: in instantiation of member function
      'strus::Reference<strus::QueryProcessorInterface>::freeRef' requested here
                freeRef();
                ^
/Users/baumann/work/strus/src/storage/libstrus_storage_objbuild.cpp:41:11: note: in instantiation of
      member function 'strus::Reference<strus::QueryProcessorInterface>::~Reference' requested here
        explicit StorageObjectBuilder( ErrorBufferInterface* errorhnd_)
                 ^
/Users/baumann/work/strus/include/strus/lib/queryeval.hpp:22:7: note: forward declaration of
      'strus::QueryProcessorInt
class QueryProcessorInterface;
      ^
```
